### PR TITLE
[Api] 회원탈퇴 수정

### DIFF
--- a/src/main/java/com/sparta/community/admin/controller/AdminCommentController.java
+++ b/src/main/java/com/sparta/community/admin/controller/AdminCommentController.java
@@ -1,7 +1,6 @@
 package com.sparta.community.admin.controller;
 
 import com.sparta.community.comment.dto.CommentRequestDto;
-import com.sparta.community.comment.dto.CommentResponseDto;
 import com.sparta.community.comment.service.CommentNoticeService;
 import com.sparta.community.common.dto.ApiResponseDto;
 import com.sparta.community.common.security.UserDetailsImpl;
@@ -31,7 +30,7 @@ public class AdminCommentController {
     // 등록된 댓글 삭제
     @DeleteMapping("/comments/{id}")
     public ResponseEntity<ApiResponseDto> deleteComment(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id) {
-        commentNoticeService.deleteNoticeComment(id, userDetails.getUser());
+        commentNoticeService.deleteComment(id, userDetails.getUser());
         return ResponseEntity.ok().body(new ApiResponseDto("댓글 삭제 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/sparta/community/admin/controller/AdminNoticeController.java
+++ b/src/main/java/com/sparta/community/admin/controller/AdminNoticeController.java
@@ -1,10 +1,10 @@
 package com.sparta.community.admin.controller;
 
 import com.sparta.community.admin.dto.NoticeListResponseDto;
+import com.sparta.community.admin.dto.NoticeResponseDto;
 import com.sparta.community.admin.service.AdminNoticeService;
 import com.sparta.community.common.dto.ApiResponseDto;
 import com.sparta.community.common.security.UserDetailsImpl;
-import com.sparta.community.post.dto.NoticeResponseDto;
 import com.sparta.community.post.dto.PostRequestDto;
 import com.sparta.community.user.entity.UserRoleEnum;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sparta/community/admin/controller/AdminUserController.java
+++ b/src/main/java/com/sparta/community/admin/controller/AdminUserController.java
@@ -5,7 +5,7 @@ import com.sparta.community.admin.dto.AdminUserResponseDto;
 import com.sparta.community.admin.dto.AdminUserRoleRequestDto;
 import com.sparta.community.admin.service.AdminUserService;
 import com.sparta.community.common.dto.ApiResponseDto;
-import com.sparta.community.user.dto.UserRequestDto;
+import com.sparta.community.user.dto.ProfileRequestDto;
 import com.sparta.community.user.entity.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,13 +31,12 @@ public class AdminUserController {
     @GetMapping("/{id}/profile")
     public ResponseEntity<AdminUserResponseDto> getUserById(@PathVariable Long id) {
         AdminUserResponseDto result = adminUserService.getUserById(id);
-
         return ResponseEntity.ok().body(result);
     }
 
     // 회원 정보 수정
     @PutMapping("/{id}/profile")
-    public ResponseEntity<ApiResponseDto> updateProfile(@PathVariable Long id, @RequestBody UserRequestDto requestDto) {
+    public ResponseEntity<ApiResponseDto> updateProfile(@PathVariable Long id, @RequestBody ProfileRequestDto requestDto) {
         adminUserService.updateUserProfile(id, requestDto);
         return ResponseEntity.ok().body(new ApiResponseDto("회원 정보 수정 완료", HttpStatus.OK.value()));
     }
@@ -54,12 +53,5 @@ public class AdminUserController {
     public ResponseEntity<ApiResponseDto> deleteUser(@PathVariable Long id) {
         adminUserService.deleteUser(id);
         return ResponseEntity.ok().body(new ApiResponseDto("회원 탈퇴 완료", HttpStatus.OK.value()));
-    }
-
-    // 회원 차단
-    @PutMapping("/block/{id}")
-    public ResponseEntity<ApiResponseDto> blockUser(@PathVariable Long id) {
-        adminUserService.blockUser(id);
-        return ResponseEntity.ok().body(new ApiResponseDto("회원 차단 완료", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/sparta/community/admin/dto/AdminUserResponseDto.java
+++ b/src/main/java/com/sparta/community/admin/dto/AdminUserResponseDto.java
@@ -10,11 +10,19 @@ import lombok.Setter;
 public class AdminUserResponseDto {
     private Long id;
     private String username;
+    private String email;
+    private String oneLiner;
+    private String nickname;
+    private String imgUrl;
     private UserRoleEnum role;
 
     public AdminUserResponseDto(User user) {
         this.id = user.getId();
         this.username = user.getUsername();
+        this.email = user.getEmail();
+        this.oneLiner = user.getOneLiner();
+        this.nickname = user.getNickname();
+        this.imgUrl = user.getImgUrl();
         this.role = user.getRole();
     }
 }

--- a/src/main/java/com/sparta/community/admin/dto/NoticeListResponseDto.java
+++ b/src/main/java/com/sparta/community/admin/dto/NoticeListResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.community.admin.dto;
 
-import com.sparta.community.post.dto.NoticeResponseDto;
 import lombok.Getter;
 
 import java.util.List;

--- a/src/main/java/com/sparta/community/admin/dto/NoticeResponseDto.java
+++ b/src/main/java/com/sparta/community/admin/dto/NoticeResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.community.post.dto;
+package com.sparta.community.admin.dto;
 
 import com.sparta.community.admin.entity.Notice;
 import com.sparta.community.comment.dto.CommentResponseDto;
@@ -18,7 +18,6 @@ public class NoticeResponseDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
-    private Integer likePost;
     private List<CommentResponseDto> comments;
 
     public NoticeResponseDto(Notice notice) {

--- a/src/main/java/com/sparta/community/admin/service/AdminNoticeService.java
+++ b/src/main/java/com/sparta/community/admin/service/AdminNoticeService.java
@@ -1,9 +1,9 @@
 package com.sparta.community.admin.service;
 
 import com.sparta.community.admin.dto.NoticeListResponseDto;
+import com.sparta.community.admin.dto.NoticeResponseDto;
 import com.sparta.community.admin.entity.Notice;
 import com.sparta.community.admin.repository.NoticeRepository;
-import com.sparta.community.post.dto.NoticeResponseDto;
 import com.sparta.community.post.dto.PostRequestDto;
 import com.sparta.community.user.entity.User;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sparta/community/admin/service/AdminUserService.java
+++ b/src/main/java/com/sparta/community/admin/service/AdminUserService.java
@@ -3,11 +3,15 @@ package com.sparta.community.admin.service;
 import com.sparta.community.admin.dto.AdminUserListResponseDto;
 import com.sparta.community.admin.dto.AdminUserResponseDto;
 import com.sparta.community.admin.dto.AdminUserRoleRequestDto;
+import com.sparta.community.comment.repository.CommentNoticeRepository;
+import com.sparta.community.comment.repository.CommentPostRepository;
+import com.sparta.community.follow.repository.FollowRepository;
 import com.sparta.community.post.entity.Post;
 import com.sparta.community.post.repository.PostRepository;
-import com.sparta.community.user.dto.UserRequestDto;
+import com.sparta.community.user.dto.ProfileRequestDto;
 import com.sparta.community.user.entity.User;
 import com.sparta.community.user.entity.UserRoleEnum;
+import com.sparta.community.user.repository.SignupAuthRepository;
 import com.sparta.community.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +26,10 @@ public class AdminUserService {
 
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final CommentPostRepository commentPostRepository;
+    private final CommentNoticeRepository commentNoticeRepository;
+    private final FollowRepository followRepository;
+    private final SignupAuthRepository signupAuthRepository;
 
     // 회원 전체 조회 > 리스트
     public AdminUserListResponseDto getUsers() {
@@ -38,7 +46,13 @@ public class AdminUserService {
     }
 
     // 회원 정보 수정 -> 기존 프로필 수정과 합쳐질 예정
-    public void updateUserProfile(Long id, UserRequestDto requestDto) {
+    @Transactional
+    public void updateUserProfile(Long id, ProfileRequestDto requestDto) {
+        User userItem = userRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다.")
+        );
+        userItem.setNickname(requestDto.getNickname());
+        userItem.setOneLiner(requestDto.getOneLiner());
     }
 
     // 회원 권한 변경
@@ -50,10 +64,14 @@ public class AdminUserService {
             throw new IllegalArgumentException("관리자는 수정할 수 없습니다.");
         }
 
+        if (requestDto.getRole().equals(user.getRole())) {
+            throw new IllegalArgumentException("기존의 권한과 변경할 권한이 동일합니다.");
+        }
+
         user.setRole(requestDto.getRole());
     }
 
-    // 탈퇴 시킬 회원의 게시글 삭제 -> 회원 탈퇴
+    // 회원 탈퇴 : 댓글 삭제 -> 게시글 삭제 -> 회원 탈퇴
     public void deleteUser(Long id) {
         User user = findUser(id);
 
@@ -61,17 +79,29 @@ public class AdminUserService {
             throw new IllegalArgumentException("관리자는 탈퇴할 수 없습니다.");
         }
 
+        if (commentPostRepository.findByUserId(id).isPresent()) {
+            commentPostRepository.deleteAll();
+        }
+
+        if (commentNoticeRepository.findByUserId(id).isPresent()) {
+            commentNoticeRepository.deleteAll();
+        }
+
+        if (followRepository.findByFollowerUserId(id).isPresent()) {
+            followRepository.deleteAll();
+        }
+
+        if (signupAuthRepository.findById(id).isPresent()) {
+            signupAuthRepository.deleteById(id);
+        }
+
         List<Post> postList = postRepository.findAllByUser(user);
         postRepository.deleteAll(postList);
         userRepository.delete(findUser(id));
     }
 
-    // 회원 차단 구현 예정
-    public void blockUser(Long id) {
-    }
-
     // id 값으로 회원을 조회하는 메소드
-    public User findUser(long id) {
+    public User findUser(Long id) {
         return userRepository.findById(id).orElseThrow(() ->
                 new IllegalArgumentException("선택한 회원은 존재하지 않습니다.")
         );

--- a/src/main/java/com/sparta/community/admin/service/AdminUserService.java
+++ b/src/main/java/com/sparta/community/admin/service/AdminUserService.java
@@ -3,10 +3,12 @@ package com.sparta.community.admin.service;
 import com.sparta.community.admin.dto.AdminUserListResponseDto;
 import com.sparta.community.admin.dto.AdminUserResponseDto;
 import com.sparta.community.admin.dto.AdminUserRoleRequestDto;
+import com.sparta.community.comment.repository.CommentLikeRepository;
 import com.sparta.community.comment.repository.CommentNoticeRepository;
 import com.sparta.community.comment.repository.CommentPostRepository;
 import com.sparta.community.follow.repository.FollowRepository;
 import com.sparta.community.post.entity.Post;
+import com.sparta.community.post.repository.PostLikeRepository;
 import com.sparta.community.post.repository.PostRepository;
 import com.sparta.community.user.dto.ProfileRequestDto;
 import com.sparta.community.user.entity.User;
@@ -30,6 +32,8 @@ public class AdminUserService {
     private final CommentNoticeRepository commentNoticeRepository;
     private final FollowRepository followRepository;
     private final SignupAuthRepository signupAuthRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final PostLikeRepository postLikeRepository;
 
     // 회원 전체 조회 > 리스트
     public AdminUserListResponseDto getUsers() {
@@ -71,7 +75,7 @@ public class AdminUserService {
         user.setRole(requestDto.getRole());
     }
 
-    // 회원 탈퇴 : 댓글 삭제 -> 게시글 삭제 -> 회원 탈퇴
+    // 회원 탈퇴 : 좋아요, 팔로우, 댓글, 게시글, 이메일인증 데이터베이스 정리
     public void deleteUser(Long id) {
         User user = findUser(id);
 
@@ -93,6 +97,14 @@ public class AdminUserService {
 
         if (signupAuthRepository.findById(id).isPresent()) {
             signupAuthRepository.deleteById(id);
+        }
+
+        if (commentLikeRepository.findById(id).isPresent()) {
+            commentLikeRepository.deleteById(id);
+        }
+
+        if (postLikeRepository.findById(id).isPresent()) {
+            postLikeRepository.deleteById(id);
         }
 
         List<Post> postList = postRepository.findAllByUser(user);

--- a/src/main/java/com/sparta/community/comment/controller/CommentNoticeController.java
+++ b/src/main/java/com/sparta/community/comment/controller/CommentNoticeController.java
@@ -42,7 +42,7 @@ public class CommentNoticeController {
     @DeleteMapping("/comments/{id}")
     public ResponseEntity<ApiResponseDto> deleteComment(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id) {
         try {
-            commentNoticeService.deleteNoticeComment(id, userDetails.getUser());
+            commentNoticeService.deleteComment(id, userDetails.getUser());
             return ResponseEntity.ok().body(new ApiResponseDto("댓글 삭제 성공", HttpStatus.OK.value()));
         } catch (RejectedExecutionException e) {
             return ResponseEntity.badRequest().body(new ApiResponseDto("작성자만 삭제 할 수 있습니다.", HttpStatus.BAD_REQUEST.value()));

--- a/src/main/java/com/sparta/community/comment/repository/CommentNoticeRepository.java
+++ b/src/main/java/com/sparta/community/comment/repository/CommentNoticeRepository.java
@@ -3,5 +3,8 @@ package com.sparta.community.comment.repository;
 import com.sparta.community.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentNoticeRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findByUserId(Long id);
 }

--- a/src/main/java/com/sparta/community/comment/repository/CommentPostRepository.java
+++ b/src/main/java/com/sparta/community/comment/repository/CommentPostRepository.java
@@ -3,5 +3,8 @@ package com.sparta.community.comment.repository;
 import com.sparta.community.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentPostRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findByUserId(Long id);
 }

--- a/src/main/java/com/sparta/community/comment/service/CommentNoticeService.java
+++ b/src/main/java/com/sparta/community/comment/service/CommentNoticeService.java
@@ -32,7 +32,7 @@ public class CommentNoticeService {
         return new CommentResponseDto(savedComment);
     }
 
-    public void deleteNoticeComment(Long id, User user) {
+    public void deleteComment(Long id, User user) {
         Comment comment = commentPostRepository.findById(id).orElseThrow();
 
         // 요청자가 운영자 이거나 댓글 작성자(post.user) 와 요청자(user) 가 같은지 체크

--- a/src/main/java/com/sparta/community/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sparta/community/follow/repository/FollowRepository.java
@@ -11,4 +11,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFollowerUserAndFollowingUser(User followerUser, User followingUser);
 
     List<Follow> findAllByFollowerUser(User user);
+
+    Optional<Follow> findByFollowerUserId(Long id);
 }

--- a/src/main/java/com/sparta/community/user/controller/HomeController.java
+++ b/src/main/java/com/sparta/community/user/controller/HomeController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class HomeController {
     @GetMapping("/")
-    public String goHome(@AuthenticationPrincipal UserDetailsImpl userDetails, Model model){
+    public String goHome(@AuthenticationPrincipal UserDetailsImpl userDetails, Model model) {
         model.addAttribute("username", userDetails.getUsername());
         return "home";
     }

--- a/src/main/java/com/sparta/community/user/controller/UserController.java
+++ b/src/main/java/com/sparta/community/user/controller/UserController.java
@@ -68,7 +68,7 @@ public class UserController {
     // 프로필 보기
     @GetMapping("/profile")
     @ResponseBody
-    public ProfileResponseDto getProfile (@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ProfileResponseDto getProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return userService.getProfile(userDetails.getUser().getId());
     }
 
@@ -77,7 +77,7 @@ public class UserController {
     @PutMapping("/profile")
     @ResponseBody
     public ResponseEntity<ApiResponseDto> updateProfile(@RequestBody ProfileRequestDto profileRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        try{
+        try {
             userService.updateProfile(profileRequestDto, userDetails.getUser());
             return ResponseEntity.ok().body(new ApiResponseDto("프로필 수정 성공", HttpStatus.OK.value()));
         } catch (IllegalArgumentException e) {
@@ -86,7 +86,7 @@ public class UserController {
     }
 
     @GetMapping("/my-page")
-    public String myPage(@AuthenticationPrincipal UserDetailsImpl userDetails, Model model){
+    public String myPage(@AuthenticationPrincipal UserDetailsImpl userDetails, Model model) {
         String email = userDetails.getUser().getEmail();
         String username = userDetails.getUsername();
         String oneLiner = userDetails.getUser().getOneLiner();

--- a/src/main/java/com/sparta/community/user/dto/UserResponseDto.java
+++ b/src/main/java/com/sparta/community/user/dto/UserResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.community.user.dto;
 
-import com.sparta.community.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,12 +16,4 @@ public class UserResponseDto {
     private String oneLiner;     // 한줄 소개
     private String nickname;
     private String imgUrl;
-
-    public UserResponseDto(User user) {
-        this.username = user.getUsername();
-        this.email = user.getEmail();
-        this.oneLiner = user.getOneLiner();
-        this.nickname = user.getNickname();
-        this.imgUrl = user.getImgUrl();
-    }
 }

--- a/src/main/java/com/sparta/community/user/entity/User.java
+++ b/src/main/java/com/sparta/community/user/entity/User.java
@@ -16,12 +16,11 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    // 로그인 시 사용 (ayboori)
     @Column(nullable = false, unique = true)
     private String username;
     @Column(nullable = false)
     private String password;
-    @Column(nullable = false, unique = true)
+    @Column(nullable = true, unique = true)
     private String email;
     // 한줄 소개
     @Column
@@ -37,24 +36,6 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
 
-
-//    public User(SignupRequestDto signupRequestDto, String password, UserRoleEnum role) {
-//        this.username = signupRequestDto.getUsername();
-//        this.password = password;
-//        this.email = signupRequestDto.getEmail();
-//        this.oneLiner = signupRequestDto.getOneLiner();
-//        this.role = role;
-//        this.imgUrl = "";
-//    }
-
-    // User 받기?
-//    public User(UserRequestDto userRequestDto) {
-//        this.username = userRequestDto.getUsername();
-//        this.email = userRequestDto.getEmail();
-//        this.oneLiner = userRequestDto.getOneLiner();
-//        this.imgUrl = "";
-//    }
-
     public User(String username, String password, String email, String oneLiner, String nickname, UserRoleEnum role) {
         this.username = username;
         this.password = password;
@@ -63,19 +44,5 @@ public class User {
         this.nickname = nickname;
         this.role = role;
     }
-
-    // 회원정보 수정
-//    public void update(ProfileRequestDto requestDto) {
-//        this.username = requestDto.getUsername();
-//        this.oneLiner = requestDto.getOneLiner();
-//    }
-
-//    public User(UserUpdateDto userupdateDto) {
-//        this.username = userupdateDto.getUsername();
-//        this.oneLiner = userupdateDto.getOneLiner();
-//        this.imgUrl = userupdateDto.getImgUrl();
-//    }
-
-
 }
 

--- a/src/main/java/com/sparta/community/user/repository/SignupAuthRepository.java
+++ b/src/main/java/com/sparta/community/user/repository/SignupAuthRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface SignupAuthRepository extends JpaRepository<SignupAuth, Long> {
     Optional<SignupAuth> findByEmail(String email);
+
+    Optional<SignupAuth> findById(Long id);
 }

--- a/src/main/java/com/sparta/community/user/service/UserService.java
+++ b/src/main/java/com/sparta/community/user/service/UserService.java
@@ -2,13 +2,12 @@ package com.sparta.community.user.service;
 
 import com.sparta.community.user.dto.ProfileRequestDto;
 import com.sparta.community.user.dto.ProfileResponseDto;
-import com.sparta.community.user.repository.SignupAuthRepository;
 import com.sparta.community.user.dto.SignupRequestDto;
 import com.sparta.community.user.entity.User;
 import com.sparta.community.user.entity.UserRoleEnum;
+import com.sparta.community.user.repository.SignupAuthRepository;
 import com.sparta.community.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,6 +59,7 @@ public class UserService {
             throw new IllegalArgumentException("입력하신 ID는 이미 존재하는 ID 입니다.");
         }
     }
+
     // email 중복 확인
     public void checkEmail(String email) {
         Optional<User> checkEmail = userRepository.findByEmail(email);

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -14,12 +14,12 @@
 
   <link rel="stylesheet" href="/css/style.css">
   <script src="/js/basic.js"></script>
-  <title>Interview Feed</title>
+  <title>백오피스 프로젝트</title>
 </head>
 <body>
 <div class="header" style="position:relative;">
   <!--headr-->
-  <div id="header-title-login-user" onclick="window.location.href='/api/mypage'">
+  <div id="header-title-login-user" onclick="window.location.href='/it/users/mypage'">
     <span id="username" th:text="${username}"></span> 님
   </div>
   <div id="header-title-interview-feed">

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div id="signup-form">
-    <div id="login-title">Sign up Interview Feed</div>
+    <div id="login-title">회원가입 페이지</div>
 
     <form action="/it/users/signup" method="post">
         <div class="login-id-label">아이디</div>
@@ -49,7 +49,7 @@
         <div class="login-id-label">한줄소개</div>
         <input type="text" name="oneLiner" placeholder="oneLiner" class="login-input-box">
 
-        <div class="login-id-label">Nickname</div>
+        <div class="login-id-label">닉네임</div>
         <input type="text" name="nickname" placeholder="nickname" class="login-input-box">
 
         <div>


### PR DESCRIPTION
인증된 이메일주소, 작성한 게시글, 작성한 댓글, 작성한 좋아요 등등 탈퇴시킬 유저의 데이터베이스를 삭제하고 최종으로 회원탈퇴를 시키는 방법으로 구현(외래키 참조 때문에 삭제가 되지 않았음)